### PR TITLE
Revert "Make besu blockchain to be available to run on windows"

### DIFF
--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -5,13 +5,12 @@ services:
   #
   node1.eea.org:
     image: hyperledger/besu:1.2.4
-    command: --data-path=/var/lib/besu_data --genesis-file=/var/lib/besu/genesis.json --rpc-http-enabled --rpc-http-host=0.0.0.0 --rpc-ws-enabled --rpc-ws-host=0.0.0.0 --discovery-enabled=false --p2p-host=0.0.0.0 --rpc-http-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-ws-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-http-cors-origins='*' --host-whitelist='*' --min-gas-price=0
+    command: --data-path=/var/lib/besu --genesis-file=/var/lib/besu/genesis.json --rpc-http-enabled --rpc-http-host=0.0.0.0 --rpc-ws-enabled --rpc-ws-host=0.0.0.0 --discovery-enabled=false --p2p-host=0.0.0.0 --rpc-http-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-ws-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-http-cors-origins='*' --host-whitelist='*' --min-gas-price=0
     ports:
       - 22011:8545
       - 22012:8546
     volumes:
       - './besu/node1:/var/lib/besu'
-      - node1_data:/var/lib/besu_data
     networks:
       devcon_net:
         ipv4_address: '172.13.0.2'
@@ -39,13 +38,12 @@ services:
   #
   node2.eea.org:
     image: hyperledger/besu:1.2.4
-    command: --data-path=/var/lib/besu_data --genesis-file=/var/lib/besu/genesis.json --rpc-http-enabled --rpc-http-host=0.0.0.0 --rpc-ws-enabled --rpc-ws-host=0.0.0.0 --discovery-enabled=false --p2p-host=0.0.0.0 --rpc-http-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-ws-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-http-cors-origins='*' --host-whitelist='*' --min-gas-price=0
+    command: --data-path=/var/lib/besu --genesis-file=/var/lib/besu/genesis.json --rpc-http-enabled --rpc-http-host=0.0.0.0 --rpc-ws-enabled --rpc-ws-host=0.0.0.0 --discovery-enabled=false --p2p-host=0.0.0.0 --rpc-http-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-ws-api=ETH,NET,WEB3,DEBUG,MINER,ADMIN,TXPOOL,CLIQUE --rpc-http-cors-origins='*' --host-whitelist='*' --min-gas-price=0
     ports:
       - 23011:8545
       - 23012:8546
     volumes:
       - './besu/node2:/var/lib/besu'
-      - node2_data:/var/lib/besu_data
     networks:
       devcon_net:
         ipv4_address: '172.13.0.4'
@@ -74,8 +72,4 @@ networks:
       driver: default
       config:
       - subnet: 172.13.0.0/16
-
-volumes:
-  node1_data:
-  node2_data:
 


### PR DESCRIPTION
Reverts EntEthAlliance/EEA-Trusted-Reward-Token#21

Realized that this creates empty datadir for each besu instance, which relies on `datadir/static-nodes.json` to find peers.

Think the original RocksDB exception is due to file permission errors.